### PR TITLE
cmake: Move inline python into a python script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,16 +563,14 @@ if(CONFIG_APPLICATION_MEMORY)
   set(KERNEL_OBJECTS_H ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/kernel_objects.h)
   set(IMACROS_KERNEL_OBJECTS_H -imacros ${KERNEL_OBJECTS_H})
 
-  add_custom_command(OUTPUT ${KERNEL_OBJECTS_H}
-    COMMAND ${PYTHON_EXECUTABLE} -c
-       \"list='$<TARGET_PROPERTY:memory_space_kernel,COMPILE_DEFINITIONS>'.split('\;') \;
-         s=('\#define NUM_KERNEL_OBJECT_FILES %s\\n' % len(list)) \;
-         s+=''.join('\#define KERNEL_OBJECT_FILE_%s %s\\n' % (i,item) for i, item in enumerate(list)) \;
-         f=open('${KERNEL_OBJECTS_H}','w') \;
-         f.write(s) \;
-         f.close() \"
-         COMMENT "Populating ${KERNEL_OBJECTS_H} with kernel space symbols"
-)
+  add_custom_command(
+    OUTPUT ${KERNEL_OBJECTS_H}
+    COMMAND ${PYTHON_EXECUTABLE}
+    ${ZEPHYR_BASE}/scripts/gen_kernel_objects.py
+    --object-files-as-csv $<JOIN:$<TARGET_PROPERTY:memory_space_kernel,COMPILE_DEFINITIONS>,,>
+    --output-file ${KERNEL_OBJECTS_H}
+    COMMENT "Populating ${KERNEL_OBJECTS_H} with kernel space symbols"
+    )
 endif(CONFIG_APPLICATION_MEMORY)
 
 # Declare MPU userspace dependencies before the linker scripts to make

--- a/scripts/gen_kernel_objects.py
+++ b/scripts/gen_kernel_objects.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+import argparse
+
+def main():
+    args = parse_args()
+
+    object_files = args.object_files_as_csv.split(',')
+
+    s = '#define NUM_KERNEL_OBJECT_FILES {}\n'.format(len(object_files))
+    for i, item in enumerate(object_files):
+        s += '#define KERNEL_OBJECT_FILE_{} {}\n'.format(i, item)
+
+    with open(args.output_file, "w") as fp:
+        fp.write(s)
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    parser.add_argument("-i", "--object-files-as-csv", required=True)
+    parser.add_argument("-o", "--output-file", required=True)
+
+    return parser.parse_args()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Refactor the generation of kernel_objects.h by moving inline python
into a python script.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>